### PR TITLE
Add http/api export support

### DIFF
--- a/export-doc-plugin/.gitignore
+++ b/export-doc-plugin/.gitignore
@@ -1,0 +1,4 @@
+/build/
+/.gradle/
+/out/
+/interface-docs/

--- a/export-doc-plugin/README.md
+++ b/export-doc-plugin/README.md
@@ -1,0 +1,17 @@
+# Interface Exporter Plugin
+
+This is a minimal IntelliJ IDEA plugin that exports interface documentation for selected methods, Java interfaces or API description files. The result can be written as HTML or Markdown.
+
+## Building the Plugin
+
+The build requires JDK 8 or JDK 11. Run:
+
+```bash
+./gradlew build
+```
+
+The generated plugin zip will be located in `build/distributions`.
+
+## Using the Plugin
+
+After installing, right‑click a method, interface, or a `.http`/`.api` file and choose **Export Interface Documentation**. You will be prompted to select **Markdown** or **HTML**. The generated file is saved in an `interface-docs` folder at the project root. The plugin targets Java 8 and therefore works on both Java 8 and Java 11 based IDEs.

--- a/export-doc-plugin/build.gradle.kts
+++ b/export-doc-plugin/build.gradle.kts
@@ -1,0 +1,32 @@
+plugins {
+    kotlin("jvm") version "1.9.0"
+    id("java")
+    id("org.jetbrains.intellij") version "1.16.0"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+}
+
+intellij {
+    version.set("2022.3")
+    type.set("IC")
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions.jvmTarget = "1.8"
+}
+
+patchPluginXml {
+    changeNotes.set("Initial version")
+}
+

--- a/export-doc-plugin/gradle.properties
+++ b/export-doc-plugin/gradle.properties
@@ -1,0 +1,1 @@
+pluginName=Interface Exporter

--- a/export-doc-plugin/src/main/kotlin/com/example/exporter/ExportAction.kt
+++ b/export-doc-plugin/src/main/kotlin/com/example/exporter/ExportAction.kt
@@ -1,0 +1,92 @@
+package com.example.exporter
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.LangDataKeys
+import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiMethod
+import java.io.File
+import java.nio.charset.StandardCharsets
+
+class ExportAction : AnAction() {
+    override fun update(e: AnActionEvent) {
+        val element = e.getData(LangDataKeys.PSI_ELEMENT)
+        val file = e.getData(CommonDataKeys.VIRTUAL_FILE)
+        val enabled =
+            element is PsiMethod ||
+                (element is PsiClass && element.isInterface) ||
+                (file != null && !file.isDirectory && (file.extension == "http" || file.extension == "api"))
+        e.presentation.isEnabledAndVisible = enabled
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val element = e.getData(LangDataKeys.PSI_ELEMENT)
+        val file = e.getData(CommonDataKeys.VIRTUAL_FILE)
+
+        val choice = Messages.showChooseDialog(
+            project,
+            "Choose export format",
+            "Export Interface",
+            arrayOf("Markdown", "HTML"),
+            "Markdown",
+            null
+        ) ?: return
+
+        val infos = when {
+            element is PsiMethod -> listOf(InterfaceInfo(element.name, element.containingFile.virtualFile.path, "METHOD"))
+            element is PsiClass && element.isInterface -> listOf(InterfaceInfo(element.name, element.containingFile.virtualFile.path, "INTERFACE"))
+            file != null && !file.isDirectory && (file.extension == "http" || file.extension == "api") -> parseApiFile(file)
+            else -> return
+        }
+
+        val outputDir = File(project.basePath ?: return, "interface-docs")
+        outputDir.mkdirs()
+
+        if (infos.isEmpty()) return
+
+        if (choice == "HTML") {
+            HtmlWriter.write(File(outputDir, "interfaces.html"), infos)
+        } else {
+            MarkdownWriter.write(File(outputDir, "interfaces.md"), infos)
+        }
+    }
+}
+
+data class InterfaceInfo(val name: String, val path: String, val type: String)
+
+object HtmlWriter {
+    fun write(file: File, interfaces: List<InterfaceInfo>) {
+        file.printWriter().use { out ->
+            out.println("<html><body><h1>Interfaces</h1><ul>")
+            interfaces.forEach { out.println("<li>${'$'}{it.name} (${it.type}) - ${'$'}{it.path}</li>") }
+            out.println("</ul></body></html>")
+        }
+    }
+}
+
+object MarkdownWriter {
+    fun write(file: File, interfaces: List<InterfaceInfo>) {
+        file.printWriter().use { out ->
+            out.println("# Interfaces")
+            interfaces.forEach { out.println("- ${'$'}{it.name} (${it.type}) - ${'$'}{it.path}") }
+        }
+    }
+}
+
+private fun parseApiFile(file: VirtualFile): List<InterfaceInfo> {
+    val lines = String(file.contentsToByteArray(), StandardCharsets.UTF_8).lines()
+    if (file.extension == "http") {
+        val regex = Regex("^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\\s+(\\S+)")
+        return lines.mapNotNull { line ->
+            val match = regex.find(line.trim()) ?: return@mapNotNull null
+            val name = match.groupValues[1] + " " + match.groupValues[2]
+            InterfaceInfo(name, file.path, "HTTP")
+        }
+    }
+    return lines.filter { it.isNotBlank() }
+        .map { InterfaceInfo(it.trim(), file.path, "CUSTOM") }
+}

--- a/export-doc-plugin/src/main/resources/META-INF/plugin.xml
+++ b/export-doc-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,0 +1,21 @@
+<idea-plugin>
+    <id>com.example.exporter</id>
+    <name>Interface Exporter</name>
+    <vendor email="support@example.com" url="https://example.com">Example</vendor>
+    <description>Export HTTP and custom interfaces to HTML or Markdown.</description>
+
+    <depends>com.intellij.modules.platform</depends>
+
+    <extensions defaultExtensionNs="com.intellij">
+    </extensions>
+
+    <actions>
+        <action id="ExportInterfacesAction"
+                class="com.example.exporter.ExportAction"
+                text="Export Interface Documentation"
+                description="Export selected interface, method, or API file">
+            <add-to-group group-id="EditorPopupMenu" anchor="last"/>
+            <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
+        </action>
+    </actions>
+</idea-plugin>


### PR DESCRIPTION
## Summary
- extend IntelliJ exporter plugin to handle `.http` and `.api` files
- add project view context menu binding
- document the new usage
- ignore generated interface docs

## Testing
- `gradle build` *(fails: BuildFlowService error due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68667e589f6083299eda9e8b3ebb7d9f